### PR TITLE
pyod 1.0.9

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,15 +11,16 @@ source:
 
 build:
   number: 0
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   host:
     - pip
-    - python >=3.5
+    - python
+    - setuptools
+    - wheel
   run:
-    - python >=3.5
+    - python
     - joblib
     - matplotlib-base
     - numba >=0.51
@@ -27,21 +28,26 @@ requirements:
     - scikit-learn >=0.20.0
     - scipy >=1.5.1
     - six
-    - statsmodels
 
 test:
   imports:
     - pyod
     - pyod.models
     - pyod.utils
+  requires:
+    - pip
+  commands:
+    - pip check
 
 about:
   home: https://github.com/yzhao062/pyod
+  dev_url: https://github.com/yzhao062/pyod
+  doc_url: https://pyod.readthedocs.io
   license: BSD-2-Clause
   license_family: BSD
   license_file: LICENSE
   summary: A Python Toolkit for Scalable Outlier Detection (Anomaly Detection)
-  doc_url: https://pyod.readthedocs.io
+  description: A Python Toolkit for Scalable Outlier Detection (Anomaly Detection)
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,6 +11,8 @@ source:
 
 build:
   number: 0
+  # numba isn't available on s390x
+  skip: true  # [s390x]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:


### PR DESCRIPTION
Changelog: https://github.com/yzhao062/pyod/blob/master/CHANGES.txt
License: https://github.com/yzhao062/pyod/blob/master/LICENSE
Requirements:
- https://github.com/yzhao062/pyod/blob/master/requirements.txt
- https://github.com/yzhao062/pyod/blob/master/setup.py

Actions:
1. Remove `noarch python`
2. Skip s390x because of missing numba
3. Add flags `--no-deps --no-build-isolation` to `script`
4. Add missing `setuptools` and `wheel` to `host`
5. Fix `python` in `host` and `run`
6. Remove `statsmodels` as it was dropped in **v.1.0.8** https://github.com/yzhao062/pyod/blob/c4aecd1dbd19b7386514d1af8978115a2dab695a/CHANGES.txt#L178
7. Add `pip check`
8. Add dev & doc urls
9. Add `description` 


Notes:
- pycaret 3.0.2 relies on it https://github.com/pycaret/pycaret/blob/fdc3f7d22a4117577340be6d8fe2db2a889e9d82/requirements.txt#LL11C1-L11C5